### PR TITLE
updated `band` with new versions of `band_func` and `year_filter`

### DIFF
--- a/R/band.R
+++ b/R/band.R
@@ -196,18 +196,42 @@ fut_band_func <- function(imageCol, data, reg, fun, scale, param, method, tmp_ty
 }
 
 band_func <- function(imageCol, reg, fun, scale, param, method, data,
-                          startDate, endDate, stat, save.plot, ggplot, variable, c.low, c.high, tmp_type){
+                       startDate, endDate, stat, save.plot, ggplot, variable, c.low, c.high, tmp_type){
 
-  tB <- imageCol$toBands()
+  # tB <- imageCol$toBands()
+  tB <-  imageCol |>
+    map_date_to_bandname_ic()
 
+  # cat("starting ee_extract\n")
   data_tb <- rgee::ee_extract(x = tB, y = reg$reg, fun = fun, scale = scale)
+  # client side
+  band_names_cli<- imageCol$first()$bandNames()$getInfo()
 
-  param_name <- paste0("_",param)
+  # regex to be removed from name to create date col
+  rm_rgx <- paste0(".*",band_names_cli)
+  rm_rgx <- glue::glue_collapse(rm_rgx,sep = "|")
 
-  proc <- data_tb %>% tidyr::pivot_longer(dplyr::contains(param_name), names_to = "Date", values_to = param)
+  # regex to extract parameter identifier
+  # reorder so shorter names with common prefix to another band names wont replace string before longer version
+  extract_rgx <- band_names_cli[stringr::str_order(band_names_cli,decreasing=T)]
+  extract_rgx <- glue::glue_collapse(extract_rgx,sep = "|")
+
+  proc <-  data_tb |>
+    # sf::st_drop_geometry() |>
+    tidyr::pivot_longer(contains(param),names_to = "measurment_id",values_to = param) |>
+    dplyr::mutate(
+      # parameter=stringr::str_extract(.data$name, pattern=extract_rgx),
+      Date= stringr::str_remove(string = .data$measurment_id, pattern = rm_rgx) |>
+        stringr::str_replace_all("_","-") |> lubridate::ymd()
+
+    ) |>
+    dplyr::select(-.data$measurment_id)
 
 
-  proc <- getting_proc(data = data, proc = proc, param_name = param_name, method = method, tmp_type = tmp_type)
+  # proc <- data_tb %>% tidyr::pivot_longer(dplyr::contains(param_name), names_to = "Date", values_to = param)
+
+
+  # proc <- getting_proc(data = data, proc = proc, param_name = param_name, method = method, tmp_type = tmp_type)
 
 
   if(ggplot == TRUE){
@@ -216,8 +240,8 @@ band_func <- function(imageCol, reg, fun, scale, param, method, data,
 
     print(proc_ggplot +
             ggplot2::labs(title = paste0(method, " ", param, ' ', stat, " values for date range: "),
-                 subtitle = paste0("Years: ",stringr::str_remove(startDate,"(-).*"), " - ", stringr::str_remove(endDate,"(-).*"), "; Months: ", c.low, " - ", c.high),
-                 y = paste0(param, ' values'), color = "ID"))
+                          subtitle = paste0("Years: ",stringr::str_remove(startDate,"(-).*"), " - ", stringr::str_remove(endDate,"(-).*"), "; Months: ", c.low, " - ", c.high),
+                          y = paste0(param, ' values'), color = "ID"))
   }
 
 

--- a/R/band2.R
+++ b/R/band2.R
@@ -1,0 +1,351 @@
+
+#' Extract Regions by Date
+#' @description This function allows the user to pass a previously created get_*() object to get
+#' a time series from a collection, e.g. banding/toBands. This uses the \link[rgee]{ee_extract} function from rgee.
+#' @param data A previously created get_* object
+#' @param geeFC A known GEE FeatureCollection or asset, e.g. "USGS/WBD/2017/HUC12"
+#' @param scale \code{numeric} value indicating what to reduce the regions by, e.g. 800 (m) default.
+#' @param band A \code{character} indicating what bands/type to use when you have more than one.
+#' @param temporal A \code{character} indicating what temporal filter to use on the collection, e.g. 'yearly' (default), 'monthly', 'year_month', 'all'.
+#' @param stat A \code{character} indicating what to reduce the ImageCollection when using temporal filtering, e.g. 'median' (default), 'mean',  'max', 'min', 'sum', 'stdDev', 'first'.
+#' @param lazy \code{logical} whether to run a 'sequential' future in the background or not.
+#' @param fun A earth engine reducer, e.g. ee$Reducer$median() (default).
+#' @param variable \code{character} indicating what to facet ggplot by. Need to know ahead of time.
+#' @param ggplot \code{logical} TRUE/FALSE. Whether to print side-effect ggplot. See details.
+#' @param save.plot \code{logical} TRUE/FALSE. Whether to save the plot in a list, e.g. data + ggplot.
+#' @param user_geom \code{logical} TRUE/FALSE.
+#' @param startDate \code{character} format date, e.g. "2018-10-23". NULL (default)
+#' @param endDate \code{character} format date, e.g. "2018-10-23". NULL (default)
+#' @param c.low \code{numeric} lower month value for calendar range. NULL (default)
+#' @param c.high \code{numeric} higher month value for calendar range. NULL (default)
+#' @note Additional arguments to pass if using a ImageCollection without get_*()'s are the startDate, endDate, c.low and c.high arguments.
+#' Faster with points or centroids of polygons.
+#' If lazy is TRUE, the function will be run in the background using a for-loop.
+#' @return A \code{data.frame} and a side-effect plot (if ggplot = TRUE); unless using \code{save.plot} then a list with \code{data.frame} and ggplot.
+#' @importFrom rlang .data
+
+#'
+#' @examples \dontrun{
+#'
+#' # Load Libraries
+#'
+#' library(rgee)
+#' ee_Initialize()
+#' library(exploreRGEE)
+#'
+#' # Bring in data
+#' huc <- exploreRGEE::huc
+#'
+#' ld8 <- get_landsat(huc, method = 'ld8', startDate = '2014-01-01',
+#'                   endDate = '2018-12-31', c.low = 6, c.high = 11)
+#'
+#' # without plotting save to object
+#' ld8_ts <- ld8 %>% band(scale = 30, band = 'NDVI')
+#'
+#' # with plotting as side-effect
+#' ld8 %>% band(scale = 30, band = 'NDVI', ggplot = TRUE, variable = 'name')
+#'
+#' # save both plot and data
+#' ld8_ts <- ld8 %>% band(scale = 30, band = 'NDVI',
+#'                        ggplot = TRUE, variable = 'name',
+#'                        save.plot = TRUE)
+#'
+#' }
+
+band <- function(data, geeFC = NULL, scale, band = NULL,
+                 temporal = 'yearly', stat = 'median', lazy = FALSE,
+                 fun = ee$Reducer$median(), variable = NULL,
+                 ggplot = FALSE, save.plot = F, user_geom = NULL, startDate = NULL,
+                 endDate = NULL, c.low = NULL, c.high = NULL) {
+
+
+  # error catching
+  if(missing(data)){stop("Need a get_* object or ImageCollection to use this function")}
+
+  if(any(class(data) == 'diff_list' | class(data) == 'terrain_list' | class(data) == 'ee.image.Image')){stop("Can't band with this type of list")}
+
+  if(!temporal %in% c('yearly', 'monthly', 'year_month', 'all')){stop("Need correct temporal argument")}
+
+  if(class(data)[[1]] == "ee.imagecollection.ImageCollection" & is.null(user_geom)){stop("Need a user geom if using ImageCollection")}
+
+  # dissecting the passed get_*() object
+
+  if(class(data)[[1]] == "ee.imagecollection.ImageCollection"){
+
+  aoi <- user_geom %>% sf::st_transform(crs = 4326, proj4string = "+init=epsg:4326")
+  imageCol <- data
+  geom <- setup(aoi)
+  method <- NULL
+  param <- NULL
+  startDate <- startDate
+  endDate <- endDate
+  c.low <- c.low
+  c.high <- c.high
+
+
+} else {
+    aoi <- data$aoi
+    imageCol <- data$imageCol
+    startDate <- data$startDate
+    endDate <- data$endDate
+    geom <- data$geom
+    method <- data$method
+    param <- data$param
+    c.low <- data$c.low
+    c.high <- data$c.high
+
+}
+  if(is.null(param) & is.null(band))stop({"Need to choose a band name."})
+
+  if(is.null(param)){
+
+    imageCol = imageCol$select(band)
+    param <- band
+
+  }
+
+  if(temporal == 'yearly'){
+
+    imageCol <- year_filter2(startDate = startDate, endDate = endDate,imageCol = imageCol, stat = stat)
+
+  } else if (temporal == 'monthly'){
+
+    imageCol <- month_filter(c.low = c.low, c.high = c.high,imageCol = imageCol, stat = stat)
+
+  } else if (temporal == 'year_month') {
+
+    imageCol <- year_month_filter(startDate = startDate, endDate = endDate,c.low = c.low, c.high = c.high,imageCol = imageCol, stat = stat)
+
+  } else if (temporal == 'all'){
+
+  }
+
+  if(is.null(geeFC)) {
+
+    reg <- sf_setup(aoi)
+
+  } else {
+
+    if (isTRUE(lazy)){
+
+    reg <- geeFC_setup_aoi(aoi, geeFC)
+
+    } else {
+
+      reg <- geeFC_setup(aoi, geeFC)
+
+  }}
+
+  if(isTRUE(lazy)){
+    prev_plan <- future::plan(future::sequential, .skip = TRUE)
+    on.exit(future::plan(prev_plan, .skip = TRUE), add = TRUE)
+    future::future({
+
+      fut_band_func(imageCol = imageCol, data = data, reg = reg, fun = fun, scale = scale, param = param, method = method, tmp_type = temporal)
+
+    }, lazy = TRUE)
+
+  } else {
+
+
+
+    band_func2(imageCol = imageCol, reg = reg, fun = fun, scale = scale, param = param,
+                  method = method, data = data, startDate = startDate, endDate = endDate, stat = stat,
+                  save.plot = save.plot, ggplot = ggplot, variable = variable, c.low = c.low, c.high = c.high, tmp_type = temporal)
+
+  }
+
+}
+
+
+# function for getting the banding
+
+fut_band_func <- function(imageCol, data, reg, fun, scale, param, method, tmp_type){
+
+
+  n_lists <- nrow(reg$aoi)/10
+
+  reggy <- reg$aoi %>%
+    dplyr::group_by((dplyr::row_number()-1) %/% (dplyr::n()/n_lists))%>%
+    tidyr::nest() %>% dplyr::pull(data)
+
+  final_proc <- data.frame()
+
+  for(i in 1:length(reggy)){
+
+    aoi <- reggy[[i]]
+
+    tB <- imageCol$toBands()
+
+    data_tb <- rgee::ee_extract(tB, aoi, fun = fun, scale = scale)
+
+    param_name <- paste0("_", param)
+
+    proc <- data_tb %>% tidyr::pivot_longer(dplyr::contains(param_name), names_to = "Date", values_to = param)
+
+
+    proc <- getting_proc(data = data, proc = proc, param_name = param_name, method = method, tmp_type = tmp_type)
+
+    final_proc <- plyr::rbind.fill(proc, final_proc)
+
+    Sys.sleep(1/100)
+
+  }
+
+  final_proc
+}
+
+band_func <- function(imageCol, reg, fun, scale, param, method, data,
+                          startDate, endDate, stat, save.plot, ggplot, variable, c.low, c.high, tmp_type){
+
+  tB <- imageCol$toBands()
+
+  data_tb <- rgee::ee_extract(x = tB, y = reg$reg, fun = fun, scale = scale)
+
+  param_name <- paste0("_",param)
+
+  proc <- data_tb %>% tidyr::pivot_longer(dplyr::contains(param_name), names_to = "Date", values_to = param)
+
+
+  proc <- getting_proc(data = data, proc = proc, param_name = param_name, method = method, tmp_type = tmp_type)
+
+
+  if(ggplot == TRUE){
+
+    proc_ggplot <- plot_proc(proc = proc, param_v = param, facet_col_var = variable)
+
+    print(proc_ggplot +
+            ggplot2::labs(title = paste0(method, " ", param, ' ', stat, " values for date range: "),
+                 subtitle = paste0("Years: ",stringr::str_remove(startDate,"(-).*"), " - ", stringr::str_remove(endDate,"(-).*"), "; Months: ", c.low, " - ", c.high),
+                 y = paste0(param, ' values'), color = "ID"))
+  }
+
+
+  if(save.plot == TRUE){
+    return(list(proc = proc, proc_ggplot = proc_ggplot))
+
+  } else {return(proc)}
+
+}
+
+# processing function for bands by 'class'
+
+
+getting_proc <- function(data, proc, param_name, method, tmp_type){
+
+  if(tmp_type == 'all'){
+
+  if(class(data) == 'met_list'){
+
+if(method == "AN81m" | method == "TERRACLIMATE"){
+
+  proc <- proc %>% dplyr::mutate(Date = stringr::str_remove_all(.data$Date, "X"),
+                                 Date = stringr::str_remove_all(.data$Date, param_name),
+                                 Date = stringr::str_replace(.data$Date,"(\\d{4})", "\\1-"),
+                                 Date = paste0(.data$Date, "-01"),
+                                 Date = lubridate::as_date(.data$Date))
+
+} else if (method == "AN81d" | method == 'GRIDMET' | method == 'DAYMET') {
+
+  proc <- proc %>% dplyr::mutate(Date = stringr::str_remove_all(.data$Date, "X"),
+                                 Date = stringr::str_remove_all(.data$Date,param_name),
+                                 Date = stringr::str_replace(.data$Date,"(\\d{4})", "\\1-"),
+                                 Date = lubridate::as_date(.data$Date))
+
+} else if (method == 'TRMMh'){
+
+  proc <- proc %>% dplyr::mutate(Date = stringr::str_remove_all(.data$Date, 'X'),
+              Date = stringr::str_remove_all(.data$Date, param_name),
+              Date = stringr::str_sub(.data$Date, start = 6),
+              Date = stringr::str_sub(.data$Date, end = -3),
+              Date = stringr::str_replace_all(.data$Date, "_", " "),
+              Date = stringr::str_replace(.data$Date, "(\\d{6})", "\\1-"),
+              Date = stringr::str_replace(.data$Date, "(\\d{4})", "\\1-"),
+              Date = paste0(.data$Date, "00"),
+              Date = lubridate::parse_date_time2(.data$Date, orders = '%Y/%m/%d %H:%M'))
+
+} else if (method == 'TRMMm'){
+
+  proc <- proc %>% dplyr::mutate(Date = stringr::str_remove_all(.data$Date, 'X'),
+                                 Date = stringr::str_remove_all(.data$Date, param_name),
+                                 Date = stringr::str_sub(.data$Date, start = 6),
+                                 Date = stringr::str_sub(.data$Date, end = -3),
+                                 Date = lubridate::as_date(.data$Date)
+                                 )
+
+}
+  } else if (class(data) == 'landsat_list'){
+
+
+    proc <- proc %>% dplyr::mutate(Date = stringr::str_remove(.data$Date, param_name),
+                                   Date = stringr::str_sub(.data$Date, start = -8),
+                                   Date = lubridate::as_date(.data$Date))
+
+  } else if (class(data) == 'sent2_list'){
+
+
+    proc <- proc %>% dplyr::mutate(Date = stringr::str_sub(.data$Date, end = 9),
+                                   Date = stringr::str_remove(.data$Date, "X"),
+                                   Date = lubridate::as_date(.data$Date))
+
+  } else if (class(data) == 'npp_list'){
+
+
+    proc <- proc %>% dplyr::mutate(Date = stringr::str_remove(.data$Date, "_annualNPP"),
+                                   Date = stringr::str_remove(.data$Date, "X"),
+                                   Date = as.numeric(.data$Date))
+
+  } else if (class(data) == 'any_list' | class(data)[[1]] == 'ee.imagecollection.ImageCollection'){
+
+
+  proc <- proc %>% dplyr::mutate(raw_date = .data$Date,
+                                 Date = dplyr::row_number())
+
+  }
+
+  } else if (tmp_type == 'year_month'){
+
+    proc <- proc %>% dplyr::mutate(Date = stringr::str_replace(.data$Date, "[^_]*_(.*)", "\\1"),
+                                   Date = stringr::str_replace(.data$Date, '_', '-'),
+                                   Date = lubridate::as_date(.data$Date))
+
+  } else if (tmp_type == 'monthly' | tmp_type == 'yearly'){
+
+    proc <- proc %>% dplyr::mutate(Date = stringr::str_remove(.data$Date, param_name),
+                                   Date = stringr::str_remove(.data$Date, "X"),
+                                   Date = as.numeric(.data$Date))
+
+  }
+
+  return(proc)
+
+}
+
+# ggplot plot for proc data
+
+plot_proc <- function(proc, param_v, facet_col_var){
+
+  mapping <- ggplot2::aes(.data$Date, .data[[param_v]], colour = .data[[facet_col_var]])
+
+  if(is.null(facet_col_var)){
+
+    mapping$colour <- NULL
+
+  }
+
+  if (is.null(facet_col_var)){
+
+    facet <- NULL
+
+  } else {
+
+    facet <- ggplot2::facet_wrap(dplyr::vars(.data[[facet_col_var]]))
+  }
+
+  proc %>% ggplot2::ggplot(mapping) +
+    ggplot2::geom_line() +
+    ggplot2::geom_smooth(alpha = 0.3) +
+    ggplot2::theme_bw()  +
+    facet
+
+}

--- a/R/band_func2.R
+++ b/R/band_func2.R
@@ -1,0 +1,57 @@
+band_func2 <- function(imageCol, reg, fun, scale, param, method, data,
+                       startDate, endDate, stat, save.plot, ggplot, variable, c.low, c.high, tmp_type){
+
+  # tB <- imageCol$toBands()
+  tB <-  imageCol |>
+    map_date_to_bandname_ic()
+
+  cat("starting ee_extract\n")
+  data_tb <- rgee::ee_extract(x = tB, y = reg$reg, fun = fun, scale = scale)
+  # client side
+  band_names_cli<- imageCol$first()$bandNames()$getInfo()
+
+  # regex to be removed from name to create date col
+  rm_rgx <- paste0(".*",band_names_cli)
+  rm_rgx <- glue::glue_collapse(rm_rgx,sep = "|")
+
+  # regex to extract parameter identifier
+  # reorder so shorter names with common prefix to another band names wont replace string before longer version
+  extract_rgx <- band_names_cli[stringr::str_order(band_names_cli,decreasing=T)]
+  extract_rgx <- glue::glue_collapse(extract_rgx,sep = "|")
+
+  proc <-  data_tb |>
+    # sf::st_drop_geometry() |>
+    tidyr::pivot_longer(contains(param),names_to = "measurment_id",values_to = param) |>
+    dplyr::mutate(
+      # parameter=stringr::str_extract(.data$name, pattern=extract_rgx),
+      Date= stringr::str_remove(string = .data$measurment_id, pattern = rm_rgx) |>
+        stringr::str_replace_all("_","-") |> lubridate::ymd()
+
+    ) |>
+    dplyr::select(-.data$measurment_id)
+
+
+  # proc <- data_tb %>% tidyr::pivot_longer(dplyr::contains(param_name), names_to = "Date", values_to = param)
+
+
+  # proc <- getting_proc(data = data, proc = proc, param_name = param_name, method = method, tmp_type = tmp_type)
+
+
+  if(ggplot == TRUE){
+
+    proc_ggplot <- plot_proc(proc = proc, param_v = param, facet_col_var = variable)
+
+    print(proc_ggplot +
+            ggplot2::labs(title = paste0(method, " ", param, ' ', stat, " values for date range: "),
+                          subtitle = paste0("Years: ",stringr::str_remove(startDate,"(-).*"), " - ", stringr::str_remove(endDate,"(-).*"), "; Months: ", c.low, " - ", c.high),
+                          y = paste0(param, ' values'), color = "ID"))
+  }
+
+
+  if(save.plot == TRUE){
+    return(list(proc = proc, proc_ggplot = proc_ggplot))
+
+  } else {return(proc)}
+
+}
+

--- a/R/ee_extract_long.R
+++ b/R/ee_extract_long.R
@@ -1,0 +1,72 @@
+#' ee_extract_long
+#' @param ic ImageCollection
+#' @param sf sf object for spatial disaggregation
+#' @param sf_col sf column to include in output
+#' @param scale scale (meters) of imageCollection
+#' @param reducer sf_col level reducer
+#' @return `rgee::ee_extract` data.frame with date & measurements pivoted long
+#' @importFrom dplyr select mutate
+#' @importFrom stringr str_remove str_replace_all str_extract
+
+
+
+
+ee_extract_long <-  function(ic,
+                             sf,
+                             sf_col,
+                             # parameter_name,
+                             scale,
+                             reducer
+                             # via="rgee_backup"
+){
+
+  reducer_fun<- switch(
+    reducer,
+    "mean" = ee$Reducer$mean(),
+    "max" = ee$Reducer$mean(),
+    "min" = ee$Reducer$min(),
+    "median"= ee$Reducer$median(),
+    "sum"= ee$Reducer$sum(),
+    "sd" = ee$Reducer$stdDev(),
+    NULL
+  )
+
+
+  cat("renaming bands with dates\n")
+  ic_renamed<- ic |>
+    map_date_to_bandname_ic()
+
+  cat("starting ee_extract\n")
+  ic_extracted_wide_sf <- rgee::ee_extract(x = ic_renamed,
+                                           y=sf[sf_col],
+                                           scale=scale,
+                                           fun= reducer_fun,
+                                           via = "drive",
+                                           sf=T)
+
+
+  # client side
+  band_names_cli<- ic$first()$bandNames()$getInfo()
+
+  # regex to be removed from name to create date col
+  rm_rgx <- paste0(".*",band_names_cli)
+  rm_rgx <- glue::glue_collapse(rm_rgx,sep = "|")
+
+  # regex to extract parameter identifier
+  # reorder so shorter names with common prefix to another band names wont replace string before longer version
+  extract_rgx <- band_names_cli[stringr::str_order(band_names_cli,decreasing=T)]
+  extract_rgx <- glue::glue_collapse(extract_rgx,sep = "|")
+
+  ic_extracted_wide_sf |>
+    sf::st_drop_geometry() |>
+    tidyr::pivot_longer(-1,names_to = "name") |>
+    mutate(
+      parameter=str_extract(.data$name, pattern=extract_rgx),
+      date= str_remove(string = .data$name, pattern = rm_rgx) |>
+        str_replace_all("_","-") |> lubridate::ymd()
+
+    ) |>
+    select(-.data$name)
+
+
+}

--- a/R/map_date_to_band_name_ic.R
+++ b/R/map_date_to_band_name_ic.R
@@ -1,0 +1,22 @@
+map_date_to_bandname_ic <- function(ic){
+  ic |>
+    ee$ImageCollection$map(
+      function(x){
+        # can't use getInfo() in sever-side function
+        bnames<- x$bandNames()
+        date <- ee$Date(x$get("system:time_start"))$format('YYYY_MM_dd')
+
+        # since bnames is technically a list rather than a simple string I need to map over it
+        # this should make it flexible fore when there are more bans I want to rename anyways
+        bnames_date <- bnames$map(
+          rgee::ee_utils_pyfunc(function(x){
+            ee$String(x)$cat(ee$String("_"))$cat(date)
+
+          })
+        )
+        x$select(bnames)$rename(bnames_date)
+      }
+
+    )
+
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -133,4 +133,22 @@ class_type <- function(data, aoi, method, param, stat,
   }
 }
 
+convert_reducer <-  function(x){switch(x,
+                                       "mean" = function(x)x$reduce(ee$Reducer$mean()),
+                                       "max" = function(x)x$reduce(ee$Reducer$max()),
+                                       "min" = function(x)x$reduce(ee$Reducer$min()),
+                                       "median"= function(x)x$reduce(ee$Reducer$median()),
+                                       "sum"= function(x)x$reduce(ee$Reducer$sum()),
+                                       "sd" =  function(x)x$reduce(ee$Reducer$stdDev()),
+                                       "first" = x$reduce(ee$Reducer$first()),
+                                       NULL
+
+)
+}
+
+
+
+
+
+
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -133,7 +133,7 @@ class_type <- function(data, aoi, method, param, stat,
   }
 }
 
-convert_reducer <-  function(x){switch(x,
+stat_to_reducer <-  function(x){switch(x,
                                        "mean" = function(x)x$reduce(ee$Reducer$mean()),
                                        "max" = function(x)x$reduce(ee$Reducer$max()),
                                        "min" = function(x)x$reduce(ee$Reducer$min()),

--- a/R/utils_filters.R
+++ b/R/utils_filters.R
@@ -71,7 +71,7 @@ year_filter <-  function(startDate, endDate, imageCol, stat){
   endYear = lubridate::year(endDate)
   years = ee$List$sequence(startYear, endYear)
 
-  ee_reducer <-  convert_reducer(stat)
+  ee_reducer <-  stat_to_reducer(stat)
 
   ee$ImageCollection$fromImages(
     years$map(rgee::ee_utils_pyfunc(function (y) {

--- a/R/utils_filters.R
+++ b/R/utils_filters.R
@@ -65,75 +65,31 @@ months = ee$List$sequence(c.low, c.high)
 
 }
 #filter by year
-year_filter <- function(startDate, endDate, imageCol, stat){
+year_filter <-  function(startDate, endDate, imageCol, stat){
 
   startYear = lubridate::year(startDate)
   endYear = lubridate::year(endDate)
-
   years = ee$List$sequence(startYear, endYear)
 
-  if(stat == "median"){
+  ee_reducer <-  convert_reducer(stat)
 
-    byYear = ee$ImageCollection$fromImages(
-      years$map(rgee::ee_utils_pyfunc(function (y) {
-        indexString = ee$Number(y)$format('%03d')
-        return(imageCol$filter(ee$Filter$calendarRange(y, y, 'year'))$median()$set('system:index', indexString))}
-      )))
+  ee$ImageCollection$fromImages(
+    years$map(rgee::ee_utils_pyfunc(function (y) {
+      indexString = ee$Number(y)$format('%03d')
+      ic_temp_filtered <- imageCol$filter(ee$Filter$calendarRange(y, y, 'year'))
+      ee_reducer(ic_temp_filtered)$
+        set('system:index', indexString)$
+        set('year',y)$
+        set('month',1)$
+        set('date',ee$Date$fromYMD(y,1,1))$
+        # set('system:time_start',ee$Date$fromYMD(y,m,1))$
+        set('system:time_start',ee$Date$millis(ee$Date$fromYMD(y,1,1)))
+    }
 
-  } else if (stat == "mean") {
-
-    byYear = ee$ImageCollection$fromImages(
-      years$map(rgee::ee_utils_pyfunc(function (y) {
-        indexString = ee$Number(y)$format('%03d')
-        return(imageCol$filter(ee$Filter$calendarRange(y, y, 'year'))$mean()$set('system:index', indexString))}
-      )))
-
-  } else if (stat == "max") {
-
-    byYear = ee$ImageCollection$fromImages(
-      years$map(rgee::ee_utils_pyfunc(function (y) {
-        indexString = ee$Number(y)$format('%03d')
-        return(imageCol$filter(ee$Filter$calendarRange(y, y, 'year'))$max()$set('system:index', indexString))}
-      )))
-
-  } else if (stat == "min") {
-
-    byYear = ee$ImageCollection$fromImages(
-      years$map(rgee::ee_utils_pyfunc(function (y) {
-        indexString = ee$Number(y)$format('%03d')
-        return(imageCol$filter(ee$Filter$calendarRange(y, y, 'year'))$min()$set('system:index', indexString))}
-      )))
-
-  } else if (stat == "sum"){
-
-    byYear = ee$ImageCollection$fromImages(
-      years$map(rgee::ee_utils_pyfunc(function (y) {
-        indexString = ee$Number(y)$format('%03d')
-        return(imageCol$filter(ee$Filter$calendarRange(y, y, 'year'))$sum()$set('system:index', indexString))}
-      )))
-
-  } else if (stat == "stdDev"){
-
-    byYear = ee$ImageCollection$fromImages(
-      years$map(rgee::ee_utils_pyfunc(function (y) {
-        indexString = ee$Number(y)$format('%03d')
-        statImage = imageCol$filter(ee$Filter$calendarRange(y, y, 'year'))$reduce(ee$Reducer$stdDev())
-        return(statImage$set('system:index', indexString))}
-      )))
-
-
-  } else if (stat == 'first'){
-
-    byYear = ee$ImageCollection$fromImages(
-      years$map(rgee::ee_utils_pyfunc(function (y) {
-        indexString = ee$Number(y)$format('%03d')
-        return(imageCol$filter(ee$Filter$calendarRange(y, y, 'year'))$first()$set('system:index', indexString))}
-      )))
-
-  }
-
-
+    ))
+  )
 }
+
 
 # function that will reduce the month per year //
 

--- a/R/year_filter2.R
+++ b/R/year_filter2.R
@@ -1,4 +1,5 @@
-#filter by year
+#' yearly filter
+#' perhaps can replcae year_filter
 
 year_filter2 <-  function(startDate, endDate, imageCol, stat){
 

--- a/R/year_filter2.R
+++ b/R/year_filter2.R
@@ -1,0 +1,27 @@
+#filter by year
+
+year_filter2 <-  function(startDate, endDate, imageCol, stat){
+
+  startYear = lubridate::year(startDate)
+  endYear = lubridate::year(endDate)
+  years = ee$List$sequence(startYear, endYear)
+
+  ee_reducer <-  convert_reducer(stat)
+
+  ee$ImageCollection$fromImages(
+    years$map(rgee::ee_utils_pyfunc(function (y) {
+    indexString = ee$Number(y)$format('%03d')
+    ic_temp_filtered <- imageCol$filter(ee$Filter$calendarRange(y, y, 'year'))
+    ee_reducer(ic_temp_filtered)$
+      set('system:index', indexString)$
+      set('year',y)$
+      set('month',1)$
+      set('date',ee$Date$fromYMD(y,1,1))$
+      # set('system:time_start',ee$Date$fromYMD(y,m,1))$
+      set('system:time_start',ee$Date$millis(ee$Date$fromYMD(y,1,1)))
+    }
+
+  ))
+  )
+}
+


### PR DESCRIPTION
I updated the code in place - check it out. I think by taking out `toBands()` we can get more out of `ee_extract`  (like multi-band extraction) what do you think? 

The only thing preventing the multi-band extraction now is the line below where the column name is getting renamed to the `param` name.
```{r}
proc <- data_tb %>% tidyr::pivot_longer(dplyr::contains(param_name), names_to = "Date", values_to = param)
```
 If we keep the pivot more generic and ad a column to describe the parameter/measurement (i.e date, parameter, value) we can pivot as many bands as we want. I have left it as is for the time being so as to not break any downstream code.

Check out the un-exported function I added `ee_extract_long.R`. It's something I had previously written which I think aims for same output: a `long` version of `rgee::ee_extract`.  It has been working pretty well and flexibly so far -perhaps we could adapt a couple parts.

I am a little confused regarding the difference of `rr` and `band` as they seem to be doing largely the same thing. Perhaps we could just make them one function? I think `rr` is a cool and simple name for the function we are after which essentially returns a clean `data.frame` with zonal stats on from an `Image` and zonal stats over time on an `ImageCollection`. Maybe we can take this conversation into another thread